### PR TITLE
CAF-2189: Updated to support header fields surrounded with asterisks

### DIFF
--- a/worker-markup-container-fs/test-data/input/CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt
+++ b/worker-markup-container-fs/test-data/input/CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt
@@ -1,0 +1,80 @@
+From: Beldin, Rick (Rick)
+Sent: Mon Oct  3 12:36:23 2016
+To: openvpn.community@lists.osp.hpe.com
+Subject: Re: Had to reimage my ubuntu workstation.....
+Importance: Normal
+
+This tends to be the most up-to-date resource for information:
+
+https://hpedia.osp.hpe.com/wiki/OpenVPN
+
+If you find something different,  please update the wiki.
+
+I use both openvpn on 16.04 as well as openconnect with the
+juniper gateways:
+
+https://hpedia.osp.hpe.com/wiki/OpenConnect
+
+I find openconnect to have somewhat better latency but it
+does seem susceptible to 'noise' that causes connections to
+occasionally drop.
+
+Rick
+
+
+
+On 10/02/2016 05:07 PM, Lee, Benson wrote:
+> Mike,
+> 
+>  
+> 
+> Which certificate are you referring to?  Is this the Class B digital badge
+> certificate or is it the SSL Certificate used for servers?  Both have been
+> migrated to http://mydigitalbadge.hpe.com/ now.
+> 
+>  
+> 
+> Thank you!
+> 
+>  
+> 
+> Benson
+> 
+>  
+> 
+> *Van:*openvpn.community-request@lists.osp.hpe.com
+> [mailto:openvpn.community-request@lists.osp.hpe.com] *On Behalf Of *Forsberg, Mike
+> *Date:* Monday, October 3, 2016 2:10 AM
+> *Recipient:* openvpn.community@lists.osp.hpe.com
+> *Objet:* Had to reimage my ubuntu workstation.....
+> 
+>  
+> 
+> Last week I reimaged my Ubuntu workstation.  After installing 16.04 I'm trying
+> to get OpenVPN working today.  I'm at the office, needed to physically enter
+> our lab, but I'd like to get OpenVPN running while I'm here.
+> 
+>  
+> 
+> I noticed that some the configuration info still references HP.  Is this still
+> right?
+> 
+>  
+> 
+> I also noticed that one can't get the certificates anymore.  They see to be
+> locked over at HP rather than accessible from HPE.
+> 
+>  
+> 
+> Any help would be appreciated,
+> 
+>  
+> 
+> Mike
+> 
+
+-- 
+Rick Beldin
+Linux ERT
+Tel: +1 770.343.0219  Email: rick.beldin@hpe.com
+Physical: 5555 Windward Parkway West, Alpharetta GA 30004

--- a/worker-markup-container-fs/test-data/input/CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt.testcase
+++ b/worker-markup-container-fs/test-data/input/CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt.testcase
@@ -1,0 +1,112 @@
+---
+tag: "CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt"
+testCaseInformation:
+  associatedTickets: null
+  comments: "CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt"
+  description: null
+  testCaseId: "CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt"
+inputData:
+  containerId: null
+  email: true
+  hashConfiguration:
+  - fields:
+    - name: "To"
+      normalizationType: "NAME_ONLY"
+    - name: "From"
+      normalizationType: "NAME_ONLY"
+    - name: "Body"
+      normalizationType: "REMOVE_WHITESPACE_AND_LINKS"
+    hashFunctions:
+    - "XXHASH64"
+    name: "Normalized"
+    scope: "EMAIL_SPECIFIC"
+  inputFile: "CAF-2189_OtherLanguageHeaderSurroundedWithAsterisks.txt"
+  outputFieldList:
+  - field: "SECTION_SORT"
+    xPathExpression: "/root/email[1]/headers/Sent/@dateUtc"
+  - field: "SECTION_ID"
+    xPathExpression: "/root/email[1]/hash/digest/@value"
+  - field: "PARENT_ID"
+    xPathExpression: "/root/email[2]/hash/digest/@value"
+  - field: "ROOT_ID"
+    xPathExpression: "/root/email[last()]/hash/digest/@value"
+  - field: "XML"
+    xPathExpression: "."
+  sourceData:
+    subject:
+    - "CAF Test Extract - simple"
+    from:
+    - "Admin/hpq%HPQ@hpswlabs.hp.com"
+    to:
+    - "Admin/hpq%hpq@hpswlabs.hp.com"
+    sent:
+    - "Thu, 19 Nov 2015 09:25:21 +0000"
+  storageReference: null
+  useDataStore: false
+expectedOutputData:
+  comparisonType: "TEXT"
+  expectedContentFile: null
+  expectedSimilarityPercentage: 0
+  fieldList:
+  - name: "SECTION_SORT"
+    value: "2016-10-03T12:36:23Z"
+  - name: "SECTION_ID"
+    value: "1c6a147953ed08c7"
+  - name: "PARENT_ID"
+    value: "3a077130a8c965fc"
+  - name: "ROOT_ID"
+    value: "120dc398b50f19f5"
+  - name: "XML"
+    value: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<root><subject>CAF Test\
+      \ Extract - simple</subject><from>Admin/hpq%HPQ@hpswlabs.hp.com</from><to>Admin/hpq%hpq@hpswlabs.hp.com</to><CONTENT><email><hash\
+      \ name=\"Normalized\"><config><fields><field name=\"To\" normalizationType=\"\
+      NAME_ONLY\" /><field name=\"From\" normalizationType=\"NAME_ONLY\" /><field\
+      \ name=\"Body\" normalizationType=\"REMOVE_WHITESPACE_AND_LINKS\" /></fields></config><digest\
+      \ function=\"XXHASH64\" value=\"1c6a147953ed08c7\" /></hash><headers><From>From:\
+      \ Beldin, Rick (Rick)</From>\r\n<Sent dateUtc=\"2016-10-03T12:36:23Z\">Sent:\
+      \ Mon Oct  3 12:36:23 2016</Sent>\r\n<To>To: openvpn.community@lists.osp.hpe.com</To>\r\
+      \n<Subject>Subject: Re: Had to reimage my ubuntu workstation.....</Subject>\r\
+      \n<Importance>Importance: Normal</Importance>\r\n</headers><body>\r\nThis tends\
+      \ to be the most up-to-date resource for information:\r\n\r\nhttps://hpedia.osp.hpe.com/wiki/OpenVPN\r\
+      \n\r\nIf you find something different,  please update the wiki.\r\n\r\nI use\
+      \ both openvpn on 16.04 as well as openconnect with the\r\njuniper gateways:\r\
+      \n\r\nhttps://hpedia.osp.hpe.com/wiki/OpenConnect\r\n\r\nI find openconnect\
+      \ to have somewhat better latency but it\r\ndoes seem susceptible to 'noise'\
+      \ that causes connections to\r\noccasionally drop.\r\n\r\nRick\r\n\r\n\r\n\r\
+      \n</body></email><email><hash name=\"Normalized\"><config><fields><field name=\"\
+      To\" normalizationType=\"NAME_ONLY\" /><field name=\"From\" normalizationType=\"\
+      NAME_ONLY\" /><field name=\"Body\" normalizationType=\"REMOVE_WHITESPACE_AND_LINKS\"\
+      \ /></fields></config><digest function=\"XXHASH64\" value=\"3a077130a8c965fc\"\
+      \ /></hash><headers>On <Sent dateUtc=\"2016-10-02T17:07:00Z\">10/02/2016 05:07\
+      \ PM</Sent>,<From> Lee, Benson </From>wrote:\r\n</headers><body>&gt; Mike,\r\
+      \n&gt; \r\n&gt;  \r\n&gt; \r\n&gt; Which certificate are you referring to? \
+      \ Is this the Class B digital badge\r\n&gt; certificate or is it the SSL Certificate\
+      \ used for servers?  Both have been\r\n&gt; migrated to http://mydigitalbadge.hpe.com/\
+      \ now.\r\n&gt; \r\n&gt;  \r\n&gt; \r\n&gt; Thank you!\r\n&gt; \r\n&gt;  \r\n\
+      &gt; \r\n&gt; Benson\r\n&gt; \r\n&gt;  \r\n&gt; \r\n</body></email><email><hash\
+      \ name=\"Normalized\"><config><fields><field name=\"To\" normalizationType=\"\
+      NAME_ONLY\" /><field name=\"From\" normalizationType=\"NAME_ONLY\" /><field\
+      \ name=\"Body\" normalizationType=\"REMOVE_WHITESPACE_AND_LINKS\" /></fields></config><digest\
+      \ function=\"XXHASH64\" value=\"7bbf9e578cd5c073\" /></hash><headers><From>&gt;\
+      \ *Van:*openvpn.community-request@lists.osp.hpe.com\r\n&gt; [mailto:openvpn.community-request@lists.osp.hpe.com]\
+      \ *On Behalf Of *Forsberg, Mike</From>\r\n</headers><body></body></email><email><hash\
+      \ name=\"Normalized\"><config><fields><field name=\"To\" normalizationType=\"\
+      NAME_ONLY\" /><field name=\"From\" normalizationType=\"NAME_ONLY\" /><field\
+      \ name=\"Body\" normalizationType=\"REMOVE_WHITESPACE_AND_LINKS\" /></fields></config><digest\
+      \ function=\"XXHASH64\" value=\"120dc398b50f19f5\" /></hash><headers><Sent dateUtc=\"\
+      2016-10-03T02:10:00Z\">&gt; *Date:* Monday, October 3, 2016 2:10 AM</Sent>\r\
+      \n<To>&gt; *Recipient:* openvpn.community@lists.osp.hpe.com</To>\r\n<Subject>&gt;\
+      \ *Objet:* Had to reimage my ubuntu workstation.....</Subject>\r\n</headers><body>&gt;\
+      \ \r\n&gt;  \r\n&gt; \r\n&gt; Last week I reimaged my Ubuntu workstation.  After\
+      \ installing 16.04 I'm trying\r\n&gt; to get OpenVPN working today.  I'm at\
+      \ the office, needed to physically enter\r\n&gt; our lab, but I'd like to get\
+      \ OpenVPN running while I'm here.\r\n&gt; \r\n&gt;  \r\n&gt; \r\n&gt; I noticed\
+      \ that some the configuration info still references HP.  Is this still\r\n&gt;\
+      \ right?\r\n&gt; \r\n&gt;  \r\n&gt; \r\n&gt; I also noticed that one can't get\
+      \ the certificates anymore.  They see to be\r\n&gt; locked over at HP rather\
+      \ than accessible from HPE.\r\n&gt; \r\n&gt;  \r\n&gt; \r\n&gt; Any help would\
+      \ be appreciated,\r\n&gt; \r\n&gt;  \r\n&gt; \r\n&gt; Mike\r\n&gt; \r\n\r\n\
+      -- \r\nRick Beldin\r\nLinux ERT\r\nTel: +1 770.343.0219  Email: rick.beldin@hpe.com\r\
+      \nPhysical: 5555 Windward Parkway West, Alpharetta GA 30004</body></email></CONTENT><sent>Thu,\
+      \ 19 Nov 2015 09:25:21 +0000</sent></root>\r\n"
+  status: "COMPLETED"

--- a/worker-markup-container-fs/testcases/automated/CAF_11013/CAF Release Process.msg.txt.testcase
+++ b/worker-markup-container-fs/testcases/automated/CAF_11013/CAF Release Process.msg.txt.testcase
@@ -59,9 +59,9 @@ expectedOutputData:
       adb8a97a124724f4\" /></hash><subject>CAF Test Extract - simple</subject><from>Admin/hpq%HPQ@hpswlabs.hp.com</from><to>Admin/hpq%hpq@hpswlabs.hp.com</to><CONTENT><email><hash\
       \ name=\"Normalized\"><config><fields><field name=\"to\" normalizationType=\"\
       NONE\" /><field name=\"body\" normalizationType=\"REMOVE_WHITESPACE\" /></fields></config><digest\
-      \ function=\"XXHASH64\" value=\"bf566245c303c4ea\" /></hash><headers><ReceivedFrom>Received\
-      \ From: Bryson, Michael</ReceivedFrom>\r\n<SentTo dateUtc=\"2016-05-19T14:17:55Z\"\
-      > Sent To: Thu May 19 14:17:55 2016</SentTo>\r\n<To> To: Ploch, Krzysztof; Comac,\
+      \ function=\"XXHASH64\" value=\"97755de20e0b741b\" /></hash><headers><ReceivedFrom>Received\
+      \ From: Bryson, Michael</ReceivedFrom>\r\n<To dateUtc=\"2016-05-19T14:17:55Z\"\
+      > Sent To: Thu May 19 14:17:55 2016</To>\r\n<To> To: Ploch, Krzysztof; Comac,\
       \ Christopher Jam; Crooks, Philip; Getty, Trevor; Hardy, Dermot; Mulholland,\
       \ Connor; Bryson, Michael; Smith, Conal; O'Loughlin, Aaron; Reid, Andy; McMurray,\
       \ Pearse P; Gibson, Dominic Joh; Payne, Alastair; Neeson, Gavin Francis; Hunter,\
@@ -81,6 +81,8 @@ expectedOutputData:
       \ this.\r\n\r\nThanks\r\n\r\nMichael Bryson\r\nQA Engineer\r\nSoftware Engineering\r\
       \nBig Data\r\n\r\nBelfast, N. Ireland\r\nmichael.bryson@hpe.com\r\n</body></email></CONTENT><sent>Thu,\
       \ 19 Nov 2015 09:25:21 +0000</sent></root>\r\n"
+  - name: "ALL_TO"
+    value: " Sent To: Thu May 19 14:17:55 2016"
   - name: "ALL_TO"
     value: " To: Ploch, Krzysztof; Comac, Christopher Jam; Crooks, Philip; Getty,\
       \ Trevor; Hardy, Dermot; Mulholland, Connor; Bryson, Michael; Smith, Conal;\

--- a/worker-markup-container-fs/testcases/automated/CAF_11029/Hotmail_test1.txt.testcase
+++ b/worker-markup-container-fs/testcases/automated/CAF_11029/Hotmail_test1.txt.testcase
@@ -72,7 +72,7 @@ expectedOutputData:
       \ /></fields></config><digest function=\"XXHASH64\" value=\"4fe77513a8a6c49b\"\
       \ /></hash><headers><From>&gt; From: bob@xxx.mailgun.org</From>\r\n<To>&gt;\
       \ To: xxx@gmail.com; xxx@hotmail.com; xxx@yahoo.com; xxx@aol.com; xxx@comcast.net;\
-      \ xxx@nyc.rr.com</To>\r\n<Date dateUtc=\"2012-04-02T13:44:22Z\">&gt; Date: Mon,\
-      \ 2 Apr 2012 17:44:22 +0400</Date>\r\n</headers><body>&gt;\r\n&gt; Hi</body></email></CONTENT><sent>Thu,\
+      \ xxx@nyc.rr.com</To>\r\n<Sent dateUtc=\"2012-04-02T13:44:22Z\">&gt; Date: Mon,\
+      \ 2 Apr 2012 17:44:22 +0400</Sent>\r\n</headers><body>&gt;\r\n&gt; Hi</body></email></CONTENT><sent>Thu,\
       \ 19 Nov 2015 09:25:21 +0000</sent></root>\r\n"
   status: "COMPLETED"

--- a/worker-markup/src/main/java/com/hpe/caf/worker/markup/MarkupHeadersAndBody.java
+++ b/worker-markup/src/main/java/com/hpe/caf/worker/markup/MarkupHeadersAndBody.java
@@ -35,10 +35,9 @@ public class MarkupHeadersAndBody
     private static final Logger LOG = LoggerFactory.getLogger(MarkupHeadersAndBody.class);
 
     public static final String UNREADABLE_HEADER = "UnreadableHeader";
-    public static final String HEADERS_WITH_ASTERISKS = "\\*(From|Sent|To|Subject):\\*";
     public static final String FROM_FIELD_WITH_ASTERISKS_SPLIT_ONTO_TWO_LINES_REGEX =
-            "(?<FirstPartFromField>[> ]{0,}\\*From:\\*[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}[\\r]?)\\n" +
-            "(?<SecondPartFromField>[> ]{0,}\\[mailto:[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}\\].*[\\r]?)";
+            "(?<FirstPartFromField>[> ]{0,}\\*.*:\\*[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}[\\r]?)\\n" +
+            "(?<SecondPartFromField>[> ]{0,}\\[.*:[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}\\].*[\\r]?)";
 
     /*
       The following GROUP_IDs correspond to the capturing groups in the RE_ON_DATE_SMB_WROTE regular expression.
@@ -56,7 +55,6 @@ public class MarkupHeadersAndBody
     private final Map<String, List<String>> emailHeaderMappings;
     private final Pattern condensedHeaderRegEx;
     private final Pattern fromFieldSplitOntoTwoLines;
-    private final Pattern headersWithAsterisks;
 
     public MarkupHeadersAndBody(
         final Map<String, List<String>> emailHeaderMappings,
@@ -69,7 +67,6 @@ public class MarkupHeadersAndBody
         final String onDateSomebodyWroteRegEx = regexSetup(condensedHeaderMultilangMappings);
         this.condensedHeaderRegEx = Pattern.compile(onDateSomebodyWroteRegEx);
         this.fromFieldSplitOntoTwoLines = Pattern.compile(FROM_FIELD_WITH_ASTERISKS_SPLIT_ONTO_TWO_LINES_REGEX);
-        this.headersWithAsterisks = Pattern.compile(HEADERS_WITH_ASTERISKS);
     }
 
     /**
@@ -134,27 +131,43 @@ public class MarkupHeadersAndBody
             // Creating headers
             String[] lines = emailText.split("\n", -1);
 
-            // Check to see if the there is a header field surrounded with '*'
-            final Matcher asterisksHeaderMatcher = headersWithAsterisks.matcher(emailText);
-            //Handle headers surrounded with asterisks separately
-            if (asterisksHeaderMatcher.find()) {
-                bodyIndex = handleHeaderWithAsterisks(emailText, lines, nattyParser, headersElement, bodyIndex);
-            } else {
-                for (String line : lines) {
-                    // Compile the regex and evaluate to get matches for the line
-                    Matcher matcher = condensedHeaderRegEx.matcher(line);
+            // If the From field value is split onto two lines (i.e This pattern is matched :'fromFieldSplitOntoTwoLines'),
+            // add them to 'fromHeaderFieldValues' so that they can be marked up together.
+            List<String> fromHeaderFieldValues = new ArrayList<>();
 
-                    // Only enter this block if we get a match i.e. line is "On xxx, abc wrote:"
-                    if (matcher.find()) {
-                        bodyIndex++;
-                        addCondensedHeader(nattyParser, headersElement, line, matcher);
-                    } // Check if the line is a header i.e. TO: xxx, making sure it is not a "On x smb wrote:" with a space after the ":"
-                    else if (line.contains(": ")) {
-                        bodyIndex++;
-                        addStandardisedHeader(nattyParser, headersElement, lines, line, ": ");
-                    } else {
-                        break;
+            // Check to see if the a field name is surrounded with '*' and it's value is split onto two lines,
+            // each line containing an email address.
+            final Matcher splitFromFieldMatcher = fromFieldSplitOntoTwoLines.matcher(emailText);
+
+            if (splitFromFieldMatcher.find()) {
+                handleHeaderWithAsterisks(emailText, lines, fromHeaderFieldValues);
+            }
+
+            for (String line : lines) {
+                // Compile the regex and evaluate to get matches for the line
+                Matcher matcher = condensedHeaderRegEx.matcher(line);
+                // If the the From field is split onto two lines, these lines need to be concatenated and marked up together.
+                // Once there is a match for the second part of the <From> value just increase the bodyIndex.
+                if (fromHeaderFieldValues.contains(line)) {
+                    bodyIndex++;
+                    if (line.equals(splitFromFieldMatcher.group("FirstPartFromField"))) {
+                        final String fullFromFieldValue = line + "\n" + splitFromFieldMatcher.group("SecondPartFromField");
+                        addStandardisedHeader(nattyParser, headersElement, lines, fullFromFieldValue, ":\\*");
                     }
+                } // Only enter this block if we get a match i.e. line is "On xxx, abc wrote:"
+                else if (matcher.find()) {
+                    bodyIndex++;
+                    addCondensedHeader(nattyParser, headersElement, line, matcher);
+                } // Check if the line is a header i.e. TO: xxx, making sure it is not a "On x smb wrote:" with a space after the ":"
+                else if (line.contains(": ")) {
+                    bodyIndex++;
+                    addStandardisedHeader(nattyParser, headersElement, lines, line, ": ");
+                } // Check if the line is a header i.e. *TO:* xxx, with an asterisk after the ":"
+                else if (line.contains(":*")) {
+                    bodyIndex++;
+                    addStandardisedHeader(nattyParser, headersElement, lines, line, ":\\*");
+                }else {
+                    break;
                 }
             }
             // Set the body text
@@ -170,20 +183,16 @@ public class MarkupHeadersAndBody
     }
 
     /**
-     * Handle the correct markup of header fields which are surrounded with '*', i.e *Sent:* xxx.
+     * Handle the correct markup of the From header field which is surrounded with '*' (i.e *From:*), and split onto two lines.
      *
      * @param emailText the email text that is to be marked up.
      * @param lines the emailText as separate lines.
-     * @param nattyParser the natty parser to detect the date language.
-     * @param headersElement the header element to add headers to.
-     * @return the email body index.
+     * @param fromHeaderFieldValues the full field value for the 'From' header.
      */
-    private int handleHeaderWithAsterisks(final String emailText, final String[] lines, final Parser nattyParser,
-                                          final Element headersElement, int bodyIndex)
+    private void handleHeaderWithAsterisks(final String emailText, final String[] lines, final List<String> fromHeaderFieldValues)
     {
         // Check to see if the the from field is split onto two lines.
         final Matcher splitFromFieldMatcher = fromFieldSplitOntoTwoLines.matcher(emailText);
-        final List<String> fromHeaderFieldValues = new ArrayList<>();
 
         if (splitFromFieldMatcher.find()) {
             for (final String line : lines) {
@@ -198,26 +207,6 @@ public class MarkupHeadersAndBody
                 }
             }
         }
-
-        for (final String line : lines) {
-            // If the the From field is split onto two lines, these lines need to be concatenated and marked up together.
-            // Once there is a match for the second part of the <From> value just increase the bodyIndex.
-            if (fromHeaderFieldValues.contains(line)) {
-                bodyIndex++;
-                if (line.equals(splitFromFieldMatcher.group("FirstPartFromField"))) {
-                    final String fullFromFieldValue = line + "\n" + splitFromFieldMatcher.group("SecondPartFromField");
-                    addStandardisedHeader(nattyParser, headersElement, lines, fullFromFieldValue, ":\\*");
-                }
-            }// Markup the remaining headers
-            else if (line.contains(":*")) {
-                bodyIndex++;
-                addStandardisedHeader(nattyParser, headersElement, lines, line, ":\\*");
-            } else {
-                break;
-            }
-        }
-
-        return bodyIndex;
     }
 
     /**

--- a/worker-markup/src/main/java/com/hpe/caf/worker/markup/MarkupHeadersAndBody.java
+++ b/worker-markup/src/main/java/com/hpe/caf/worker/markup/MarkupHeadersAndBody.java
@@ -282,7 +282,7 @@ public class MarkupHeadersAndBody
     {
         // Split out the header name and value
         final String[] colonSplit = line.split(valueToSplitOn, 2);
-        final String headerName = colonSplit[0];
+        final String headerName = removeInvalidBeginningChars(colonSplit[0]);
         final String headerValue = colonSplit[1];
 
         // Header Names are standardised against a supplied set of names
@@ -298,6 +298,18 @@ public class MarkupHeadersAndBody
         }
 
         setDateAttributeIfExists(nattyParser, headerValue, elementName, header);
+    }
+
+    /**
+     * Remove invalid characters from the beginning of a header name.
+     * To allow the 'EmailHeaderMappings' to be mapped correctly.
+     *
+     * @param headerName the header name to have invalid characters removed.
+     * @return the header name without leading invalid
+     */
+    private static String removeInvalidBeginningChars(String headerName)
+    {
+        return headerName.replaceAll("[>\\*]", "").trim();
     }
 
     /**

--- a/worker-markup/src/test/java/com/hpe/caf/worker/markup/MarkupOfHeadersAndBodyTest.java
+++ b/worker-markup/src/test/java/com/hpe/caf/worker/markup/MarkupOfHeadersAndBodyTest.java
@@ -153,6 +153,23 @@ public class MarkupOfHeadersAndBodyTest
         assertTrue(TestUtility.compareHeaderElements(docForComparison, xmlDocument));
     }
 
+   /*
+    * Testing markup of headers surrounded with asterisks,the From field split over two lines, and in a different language
+    */
+    @Test
+    public void testFromFieldSurroundedWithAsterisksOtherLanguage() throws IOException, JDOMException
+    {
+        Document xmlDocument = TestUtility.readXmlFile("src/test/resources/xml/OtherLanguageHeaderSurroundedWithAsterisks.xml");
+        MarkupHeadersAndBody.markUpHeadersAndBody(xmlDocument, emailHeaderMappings, condensedHeaderMultiLangMappings);
+        Document docForComparison = TestUtility.readXmlFile("src/test/resources/xml/OtherLanguageHeaderSurroundedWithAsterisksExpected.xml");
+
+        String docMarkedupValue = xmlDocument.getRootElement().getValue();
+        String docForComparisonValue = docForComparison.getRootElement().getValue();
+
+        assertEquals(docForComparisonValue, docMarkedupValue);
+        assertTrue(TestUtility.compareHeaderElements(docForComparison, xmlDocument));
+    }
+
     /*
      * Testing markup of one email tag
      */

--- a/worker-markup/src/test/resources/xml/OtherLanguageHeaderSurroundedWithAsterisks.xml
+++ b/worker-markup/src/test/resources/xml/OtherLanguageHeaderSurroundedWithAsterisks.xml
@@ -1,0 +1,54 @@
+<!--
+
+    Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<root><CONTENT><email>> *Van:*openvpn.community-request@lists.osp.hpe.com
+> [mailto:openvpn.community-request@lists.osp.hpe.com] *On Behalf Of *Forsberg, Mike
+> *Date:* Monday, October 3, 2016 2:10 AM
+> *Recipient:* openvpn.community@lists.osp.hpe.com
+> *Objet:* Had to reimage my ubuntu workstation.....
+> 
+>  
+> 
+> Last week I reimaged my Ubuntu workstation.  After installing 16.04 I'm trying
+> to get OpenVPN working today.  I'm at the office, needed to physically enter
+> our lab, but I'd like to get OpenVPN running while I'm here.
+> 
+>  
+> 
+> I noticed that some the configuration info still references HP.  Is this still
+> right?
+> 
+>  
+> 
+> I also noticed that one can't get the certificates anymore.  They see to be
+> locked over at HP rather than accessible from HPE.
+> 
+>  
+> 
+> Any help would be appreciated,
+> 
+>  
+> 
+> Mike
+> 
+
+-- 
+Rick Beldin
+Linux ERT
+Tel: +1 770.343.0219  Email: rick.beldin@hpe.com
+Physical: 5555 Windward Parkway West, Alpharetta GA 30004
+</email></CONTENT></root>

--- a/worker-markup/src/test/resources/xml/OtherLanguageHeaderSurroundedWithAsterisksExpected.xml
+++ b/worker-markup/src/test/resources/xml/OtherLanguageHeaderSurroundedWithAsterisksExpected.xml
@@ -1,0 +1,54 @@
+<!--
+
+    Copyright 2015-2017 Hewlett Packard Enterprise Development LP.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<root><CONTENT><email><headers><Van>> *Van:*openvpn.community-request@lists.osp.hpe.com
+> [mailto:openvpn.community-request@lists.osp.hpe.com] *On Behalf Of *Forsberg, Mike</Van>
+<Date dateUtc="2016-10-03T02:10:00Z\">> *Date:* Monday, October 3, 2016 2:10 AM</Date>
+<To>> *Recipient:* openvpn.community@lists.osp.hpe.com</To>
+<Objet>> *Objet:* Had to reimage my ubuntu workstation.....</Objet></headers><body>
+> 
+>  
+> 
+> Last week I reimaged my Ubuntu workstation.  After installing 16.04 I'm trying
+> to get OpenVPN working today.  I'm at the office, needed to physically enter
+> our lab, but I'd like to get OpenVPN running while I'm here.
+> 
+>  
+> 
+> I noticed that some the configuration info still references HP.  Is this still
+> right?
+> 
+>  
+> 
+> I also noticed that one can't get the certificates anymore.  They see to be
+> locked over at HP rather than accessible from HPE.
+> 
+>  
+> 
+> Any help would be appreciated,
+> 
+>  
+> 
+> Mike
+> 
+
+-- 
+Rick Beldin
+Linux ERT
+Tel: +1 770.343.0219  Email: rick.beldin@hpe.com
+Physical: 5555 Windward Parkway West, Alpharetta GA 30004
+</body></email></CONTENT></root>


### PR DESCRIPTION
See separate commits: 
- CAF-2189: Update so that 'emailHeaderMappings' are respected.
- CAF-2189: Updated to support header fields in another language surrounded by asterisks