### PR TITLE
CAF-3162 & CAF-3161

### DIFF
--- a/jep-talon-image/pom.xml
+++ b/jep-talon-image/pom.xml
@@ -74,7 +74,7 @@
                     <images>
                         <image>
                             <alias>jep_talon-image</alias>
-                            <name>rh7-artifactory.svs.hpeswlab.net:8443/caf/jep_talon-image:${project.version}</name>
+                            <name>${containers.jep-talon.name}</name>
                             <build>
                                 <from>java:8</from>
                                 <maintainer>adam.pau.rogan@hpe.com</maintainer>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     
     <properties>
         <caf.worker-framework.version>1.9.0-260</caf.worker-framework.version>
+        <containers.jep-talon.name>cafinternal/prereleases:jep_talon-image-${project.version}</containers.jep-talon.name>
     </properties>
 
     <dependencyManagement>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -317,7 +317,7 @@
                             <name>cafinternal/prereleases:worker-markup-${project.version}</name>
                             <build>
                                 <maintainer>conal.smith@hpe.com</maintainer>
-                                <from>{containers.jep-talon.name}</from>
+                                <from>${containers.jep-talon.name}</from>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
                                     <Build.Date>${maven.build.timestamp}</Build.Date>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -233,7 +233,7 @@
                     <watchInterval>500</watchInterval>
                     <logDate>default</logDate>
                     <verbose>true</verbose>
-                    <autoPull>always</autoPull>
+                    <autoPull>on</autoPull>
                     <images>
 
                         <image>
@@ -317,7 +317,7 @@
                             <name>cafinternal/prereleases:worker-markup-${project.version}</name>
                             <build>
                                 <maintainer>conal.smith@hpe.com</maintainer>
-                                <from>rh7-artifactory.svs.hpeswlab.net:8443/caf/jep_talon-image:${project.version}</from>
+                                <from>{containers.jep-talon.name}</from>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
                                     <Build.Date>${maven.build.timestamp}</Build.Date>

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/ConvertSourceData.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/ConvertSourceData.java
@@ -40,7 +40,7 @@ public class ConvertSourceData
             for (FieldValue fieldValue : field.getValues()) {
                 if (fieldValue.isReference()) {
                     sourceData.put(field.getName(), ReferencedData.getReferencedData(fieldValue.getReference()));
-                } else if (!fieldValue.isStringValue()) {
+                } else {
                     sourceData.put(field.getName(), ReferencedData.getWrappedData(fieldValue.getValue()));
                 }
             }


### PR DESCRIPTION
CAF-3162: Update jep-talon image to push to cafinternal prereleases and change markup worker autoPull setting so that it uses the just built local image during a build run.

CAF-3161: Fix for issue where string values were not being used during markup.
