### PR TITLE
SCMOD-4347: Improve performance of Matcher.find()

### DIFF
--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -415,7 +415,29 @@
                 <worker.adminport>8081</worker.adminport>
             </properties>
         </profile>
-
+        
+        <profile>
+            <id>skipTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven.failsafe.version}</version>
+                        <configuration>
+                            <skipITs>true</skipITs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
         <profile>
             <id>nightly-test</id>
             <activation>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -415,7 +415,7 @@
                 <worker.adminport>8081</worker.adminport>
             </properties>
         </profile>
-        
+
         <profile>
             <id>nightly-test</id>
             <activation>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -415,6 +415,7 @@
                 <worker.adminport>8081</worker.adminport>
             </properties>
         </profile>
+        
         <profile>
             <id>nightly-test</id>
             <activation>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -415,29 +415,6 @@
                 <worker.adminport>8081</worker.adminport>
             </properties>
         </profile>
-        
-        <profile>
-            <id>skipTests</id>
-            <activation>
-                <property>
-                    <name>skipTests</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${maven.failsafe.version}</version>
-                        <configuration>
-                            <skipITs>true</skipITs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
         <profile>
             <id>nightly-test</id>
             <activation>

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
@@ -74,15 +74,16 @@ public class EmailSplitter
             e.removeContent();
 
             for (String email : emailList) {
-                // We will attempt to match the regex to find "---------- Forwarded Message ---------" or similar dividers
-                if (matcher == null) {
-                    matcher = dividerPattern.matcher(email);
-                } else {
-                    matcher = matcher.reset(email);
-                }
+               
                 String divider = null; // null to make a decision later.
                 // If we find a match, strip out the divider from the email text.
                 if (email.contains(FORWARDED_MESSAGE_CHECKER)) {
+                     // We will attempt to match the regex to find "---------- Forwarded Message ---------" or similar dividers
+                    if (matcher == null) {
+                        matcher = dividerPattern.matcher(email);
+                    } else {
+                        matcher = matcher.reset(email);
+                    }
                     if (matcher.find()) {
                         divider = matcher.group(DIVIDER_GROUP_ID);//group 1 matches the divider in the regex above
                         email = email.substring(0, email.indexOf(divider));

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
@@ -48,19 +48,20 @@ public class EmailSplitter
         this.jepExec = jepExec;
 
         /**
-         * Searches the email line for the email divider i.e. "---------- Forwarded message ----------" - "(\n|^)" is the 1st capturing
-         * group which makes sure a divider line isn't matched if there is text before it i.e. "jdiwaowa ----- Forwarded message -----" -
-         * "( |>)*+" is the 3rd capturing group which matches any number of spaces or email quotation markers (">" symbols). -
-         * "*+-++[^-]++-++\s*+" matches the actual divider text i.e. "---- abc ----" - "$" makes sure the divider is at the end of the
-         * line. - This regex has a + quantifier after each of the quantifiers specified i.e. "*+" instead of just "*". This was done to
-         * reduce back tracing and reduce the anchor points the regex would hold on to. This modification was performed to prevent the
-         * regex from throwing StackOverflowErrors, the Jira this work relates to is SCMOD-3065.
+         * Searches the email line for the email divider i.e. "---------- Forwarded message ----------"
+         * - "(\n|^)" is the 1st capturing group which makes sure a divider line isn't matched if there is text before it i.e.
+         * "jdiwaowa   ----- Forwarded message -----"
+         * - "( |>)*+" is the 3rd capturing group which matches any number of spaces or email quotation markers (">" symbols).
+         * - "*+-++[^-]++-++\s*+" matches the actual divider text i.e. "---- abc ----"
+         * - "$" makes sure the divider is at the end of the line.
+         * - This regex has a + quantifier after each of the quantifiers specified i.e. "*+" instead of just "*". This was done to reduce
+         * back tracing and reduce the anchor points the regex would hold on to. This modification was performed to prevent the regex from
+         * throwing StackOverflowErrors, the Jira this work relates to is SCMOD-3065.
          */
         this.dividerPattern = Pattern.compile("(\n|^)(( |>)*+-++[^-]++-++\\s*+)$");
     }
 
-    public void generateEmailTags(Document doc) throws JDOMException, ExecutionException, InterruptedException
-    {
+    public void generateEmailTags(Document doc) throws JDOMException, ExecutionException, InterruptedException {
         LOG.info("Starting email splitting based on document received");
         validateDocument(doc);
 

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
@@ -69,7 +69,7 @@ public class MarkupHeadersAndBody
 
         // Set up the regular expression that matches the condensed header
         final String onDateSomebodyWroteRegEx = regexSetup(condensedHeaderMultilangMappings);
-        this.multilangHeadersElements = fillInList(condensedHeaderMultilangMappings);
+        this.multilangHeadersElements = getListOfElementsFromCondensedHeaderMultilangMappings(condensedHeaderMultilangMappings);
         this.condensedHeaderRegEx = Pattern.compile(onDateSomebodyWroteRegEx);
         this.fromFieldSplitOntoTwoLines = Pattern.compile(FROM_FIELD_WITH_ASTERISKS_SPLIT_ONTO_TWO_LINES_REGEX);
     }
@@ -182,7 +182,7 @@ public class MarkupHeadersAndBody
                     bodyIndex++;
                     addStandardisedHeader(nattyParser, headersElement, lines, line, ":\\*");
                 } // Only enter this block if we get a match i.e. line is "On xxx, abc wrote:"
-                else if (containsWhatSearched(line)) {
+                else if (checkPresenceOfMultilangHeadersElements(line)) {
                     if (matcher.find()) {
                         bodyIndex++;
                         addCondensedHeader(nattyParser, headersElement, line, matcher);
@@ -214,7 +214,7 @@ public class MarkupHeadersAndBody
      * @param input a string to be checked
      * @return true if some element has been found, false otherwise
      */
-    private boolean containsWhatSearched(String input)
+    private boolean checkPresenceOfMultilangHeadersElements(final String input)
     {
         return multilangHeadersElements.parallelStream().anyMatch(input::contains);
     }
@@ -485,7 +485,7 @@ public class MarkupHeadersAndBody
             if(on_list != null) on_pattern_quoted.addAll(on_list.stream().map(Pattern::quote).collect(Collectors.toList()));
             if(separator_list != null) separator_pattern_quoted.addAll(separator_list.stream().map(Pattern::quote).collect(Collectors.toList()));
             if(wrote_list != null) wrote_pattern_quoted.addAll(wrote_list.stream().map(Pattern::quote).collect(Collectors.toList()));
-            }
+        }
 
         // Join the arrays into one string separated with or separator "|".
         return "(-*[>]?[ ]?(" + String.join("|", on_pattern_quoted) + ")[ ])(.*)(" + String.join("|", separator_pattern_quoted)
@@ -500,7 +500,7 @@ public class MarkupHeadersAndBody
      * @param condensedHeaderMultilangMappings
      * @return a list with all he values of the param
      */
-    private List<String> fillInList(Map<String, List<String>> condensedHeaderMultilangMappings)
+    private List<String> getListOfElementsFromCondensedHeaderMultilangMappings(Map<String, List<String>> condensedHeaderMultilangMappings)
     {
         final Set<String> result = new HashSet<>();
         if (condensedHeaderMultilangMappings != null && !condensedHeaderMultilangMappings.isEmpty()) {

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
@@ -36,7 +36,7 @@ public class MarkupHeadersAndBody
 
     public static final String UNREADABLE_HEADER = "UnreadableHeader";
     public static final String FROM_FIELD_WITH_ASTERISKS_SPLIT_ONTO_TWO_LINES_REGEX
-        = "(?<FirstPartFromField>[> ]{0,}\\*.*:\\*[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}[\\r]?)?+\\n"
+        = "(?<FirstPartFromField>[> ]{0,}\\*.*:\\*[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}[\\r]?)\\n"
         + "(?<SecondPartFromField>[> ]{0,}\\[.*:[A-z0-9][-A-z0-9_\\+\\.]*[A-z0-9]@[A-z0-9][-A-z0-9\\.]*[A-z0-9]\\.[A-z0-9]{1,3}\\].*[\\r]?)";
     public static final String GENERAL_CHECK_ONE = ">";
     public static final String GENERAL_CHECK_TWO = "*";
@@ -173,6 +173,10 @@ public class MarkupHeadersAndBody
                         final String fullFromFieldValue = line + "\n" + splitFromFieldMatcher.group("SecondPartFromField");
                         addStandardisedHeader(nattyParser, headersElement, lines, fullFromFieldValue, ":\\*");
                     }
+                } // Only enter this block if we get a match i.e. line is "On xxx, abc wrote:"
+                else if (checkPresenceOfMultilangHeadersElements(line) && matcher.find()) {
+                    bodyIndex++;
+                    addCondensedHeader(nattyParser, headersElement, line, matcher);
                 } // Check if the line is a header i.e. TO: xxx, making sure it is not a "On x smb wrote:" with a space after the ":"
                 else if (line.contains(": ")) {
                     bodyIndex++;
@@ -181,10 +185,6 @@ public class MarkupHeadersAndBody
                 else if (line.contains(":*")) {
                     bodyIndex++;
                     addStandardisedHeader(nattyParser, headersElement, lines, line, ":\\*");
-                } // Only enter this block if we get a match i.e. line is "On xxx, abc wrote:"
-                else if (checkPresenceOfMultilangHeadersElements(line) && matcher.find()) {
-                    bodyIndex++;
-                    addCondensedHeader(nattyParser, headersElement, line, matcher);
                 } else {
                     break;
                 }

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
@@ -182,13 +182,9 @@ public class MarkupHeadersAndBody
                     bodyIndex++;
                     addStandardisedHeader(nattyParser, headersElement, lines, line, ":\\*");
                 } // Only enter this block if we get a match i.e. line is "On xxx, abc wrote:"
-                else if (checkPresenceOfMultilangHeadersElements(line)) {
-                    if (matcher.find()) {
-                        bodyIndex++;
-                        addCondensedHeader(nattyParser, headersElement, line, matcher);
-                    } else {
-                        break;
-                    }
+                else if (checkPresenceOfMultilangHeadersElements(line) && matcher.find()) {
+                    bodyIndex++;
+                    addCondensedHeader(nattyParser, headersElement, line, matcher);
                 } else {
                     break;
                 }

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/MarkupHeadersAndBody.java
@@ -140,7 +140,7 @@ public class MarkupHeadersAndBody
             final Matcher splitFromFieldMatcher = fromFieldSplitOntoTwoLines.matcher(emailText);
 
             if (splitFromFieldMatcher.find()) {
-                handleHeaderWithAsterisks(emailText, lines, fromHeaderFieldValues);
+                handleHeaderWithAsterisks(lines, fromHeaderFieldValues, splitFromFieldMatcher);
             }
 
             for (String line : lines) {
@@ -192,22 +192,18 @@ public class MarkupHeadersAndBody
      * @param lines the emailText as separate lines.
      * @param fromHeaderFieldValues the full field value for the 'From' header.
      */
-    private void handleHeaderWithAsterisks(final String emailText, final String[] lines, final List<String> fromHeaderFieldValues)
+    private void handleHeaderWithAsterisks(final String[] lines, final List<String> fromHeaderFieldValues,
+                                           final Matcher splitFromFieldMatcher)
     {
-        // Check to see if the the from field is split onto two lines.
-        final Matcher splitFromFieldMatcher = fromFieldSplitOntoTwoLines.matcher(emailText);
-
-        if (splitFromFieldMatcher.find()) {
-            for (final String line : lines) {
-                // For a line which matches the format:
-                // "*From:*example.emailaddress.com
-                // [mailto:example.emailaddress.com] *On Behalf Of *Bloggs, Joe"
-                // Add these lines to a list so that they can be marked up together later.
-                if (line.equals(splitFromFieldMatcher.group("FirstPartFromField"))) {
-                    fromHeaderFieldValues.add(line);
-                } else if (line.equals(splitFromFieldMatcher.group("SecondPartFromField"))) {
-                    fromHeaderFieldValues.add(line);
-                }
+        for (final String line : lines) {
+            // For a line which matches the format:
+            // "*From:*example.emailaddress.com
+            // [mailto:example.emailaddress.com] *On Behalf Of *Bloggs, Joe"
+            // Add these lines to a list so that they can be marked up together later.
+            if (line.equals(splitFromFieldMatcher.group("FirstPartFromField"))) {
+                fromHeaderFieldValues.add(line);
+            } else if (line.equals(splitFromFieldMatcher.group("SecondPartFromField"))) {
+                fromHeaderFieldValues.add(line);
             }
         }
     }
@@ -455,7 +451,7 @@ public class MarkupHeadersAndBody
             if(on_list != null) on_pattern_quoted.addAll(on_list.stream().map(Pattern::quote).collect(Collectors.toList()));
             if(separator_list != null) separator_pattern_quoted.addAll(separator_list.stream().map(Pattern::quote).collect(Collectors.toList()));
             if(wrote_list != null) wrote_pattern_quoted.addAll(wrote_list.stream().map(Pattern::quote).collect(Collectors.toList()));
-        }
+            }
 
         // Join the arrays into one string separated with or separator "|".
         return "(-*[>]?[ ]?(" + String.join("|", on_pattern_quoted) + ")[ ])(.*)(" + String.join("|", separator_pattern_quoted)


### PR DESCRIPTION
https://jira.autonomy.com/browse/SCMOD-4347

* Duplicated calls to Matcher.find() removed (see handleHeaderWithAsterisks() method)
* Small modification to the regex pattern FROM_FIELD_WITH_ASTERISKS_SPLIT_ONTO_TWO_LINES_REGEX to use a possessive quantifier in the first group (I have tried also different quantifiers, but the changes from a performance point of view were not relevant)
* In order to minimize the calls to matcher.find(), I have introduced checks that use String.contains() with usually a subset of what is checked in the patterns. For example, I check for ">", "*" and "\n", if they are found, then it is worthwhile to actually run the matcher, otherwise the call is skipped. In the condensedMultilangHeaders there is the "," character, which means that the check that I do to verify if any of them is present will most likely always be true (I doubt there are many emails without a comma)
* In order to minimize the usage of the memory, I tried to reduce the creation of objects by using Matcher.reset() every time that it is possible.