### PR TITLE
SCMOD-8287: Updated to handle double dividers

### DIFF
--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
@@ -35,7 +35,6 @@ public class EmailSplitter
     private static final String FORWARDED_MESSAGE_CHECKER = "--";
 
     private final JepExecutor jepExec;
-    private final String dividerPatternString;
     private final Pattern dividerPattern;
     private final Pattern dividerConfirmationPattern;
 
@@ -60,8 +59,7 @@ public class EmailSplitter
          * back tracing and reduce the anchor points the regex would hold on to. This modification was performed to prevent the regex from
          * throwing StackOverflowErrors, the Jira this work relates to is SCMOD-3065.
          */
-        this.dividerPatternString = "(\n|^)(( |>)*+-++[^-]++-++\\s*+)$";
-        this.dividerPattern = Pattern.compile(dividerPatternString);
+        this.dividerPattern = Pattern.compile("(\n|^)(( |>)*+-++[^-]++-++\\s*+)$");
         this.dividerConfirmationPattern = Pattern.compile(".*([A-Za-z])+\\s*.*");
     }
 
@@ -94,7 +92,7 @@ public class EmailSplitter
                             final String emailTemp = email.substring(0, email.indexOf(divider));
                             final String restOfEmail = email.substring(emailTemp.length() + divider.length());
                             email = emailTemp;
-                            divider = restOfEmail.matches(dividerPatternString) ? divider + restOfEmail : divider;
+                            divider = dividerPattern.matcher(restOfEmail).find() ? divider + restOfEmail : divider;
                         } else {
                             divider = null;
                         }

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
@@ -35,6 +35,7 @@ public class EmailSplitter
     private static final String FORWARDED_MESSAGE_CHECKER = "--";
 
     private final JepExecutor jepExec;
+    private final String dividerPatternString;
     private final Pattern dividerPattern;
     private final Pattern dividerConfirmationPattern;
 
@@ -59,7 +60,8 @@ public class EmailSplitter
          * back tracing and reduce the anchor points the regex would hold on to. This modification was performed to prevent the regex from
          * throwing StackOverflowErrors, the Jira this work relates to is SCMOD-3065.
          */
-        this.dividerPattern = Pattern.compile("(\n|^)(( |>)*+-++[^-]++-++\\s*+)$");
+        this.dividerPatternString = "(\n|^)(( |>)*+-++[^-]++-++\\s*+)$";
+        this.dividerPattern = Pattern.compile(dividerPatternString);
         this.dividerConfirmationPattern = Pattern.compile(".*([A-Za-z])+\\s*.*");
     }
 
@@ -89,7 +91,10 @@ public class EmailSplitter
                     if (matcher.find()) {
                         divider = matcher.group(DIVIDER_GROUP_ID);//group 1 matches the divider in the regex above
                         if (dividerConfirmationPattern.matcher(divider).find()) {
-                            email = email.substring(0, email.indexOf(divider));
+                            final String emailTemp = email.substring(0, email.indexOf(divider));
+                            final String restOfEmail = email.substring(emailTemp.length() + divider.length());
+                            email = emailTemp;
+                            divider = restOfEmail.matches(dividerPatternString) ? divider + restOfEmail : divider;
                         } else {
                             divider = null;
                         }

--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitter.java
@@ -92,7 +92,7 @@ public class EmailSplitter
                             final String emailTemp = email.substring(0, email.indexOf(divider));
                             final String restOfEmail = email.substring(emailTemp.length() + divider.length());
                             email = emailTemp;
-                            divider = dividerPattern.matcher(restOfEmail).find() ? divider + restOfEmail : divider;
+                            divider = dividerPattern.matcher(restOfEmail).matches()? divider + restOfEmail : divider;
                         } else {
                             divider = null;
                         }

--- a/worker-markup-core/src/test/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitterTest.java
+++ b/worker-markup-core/src/test/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitterTest.java
@@ -249,7 +249,7 @@ public class EmailSplitterTest
         //Assert value of email content should not have changed during processing
         Assert.assertTrue("The email is not as expected.", doc.getRootElement().getChild("CONTENT").getValue().equals(expectedEmail1));
     }
-
+    
     /**
      * Tests for running EmailSplitter with 2 emails and a divider between them
      *
@@ -297,6 +297,59 @@ public class EmailSplitterTest
         Assert.assertTrue("Assert the first email is as expected.", doc.getRootElement().getChild("CONTENT").getChildren().get(0).getValue().equals(expectedEmail1));
         Assert.assertTrue("Assert the divider is as expected.", doc.getRootElement().getChild("CONTENT").getChildren().get(1).getValue().equals(expectedDivider));
         Assert.assertTrue("Assert the second email is as expected.", doc.getRootElement().getChild("CONTENT").getChildren().get(2).getValue().equals(expectedEmail2));
+    }
+    
+    /**
+     * Tests for running EmailSplitter with 2 emails and a double divider at the end of the chain
+     *
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void splitEmailWithDoubleDividerAtEndOfChain() throws Exception
+    {
+        final String expectedEmail1 = "From: Reid, Andy\n"
+            + "Sent: 22 July 2016 10:21 AM\n"
+            + "To: Paul, Navamoni\n"
+            + "Cc: Ploch, Krzysztof\n"
+            + "Subject: RE: iSTF - CAF Integration    \n"
+            + "Hi Navamoni,\n"
+            + "\n"
+            + "Is this ready yet?\n"
+            + "\n"
+            + "Thanks, Andy\n"
+            + "\n";
+        final String expectedDivider = "------- Forwarded message follows -------\n"
+            +"   \n"
+            +"\n";
+        final String expectedEmail2 = "From: Smith, Conal\n"
+            + "Sent: 22 July 2016 11:21 AM\n"
+            + "To: Paul, Navamoni\n"
+            + "Cc: Ploch, Krzysztof\n"
+            + "Subject: RE: iSTF - CAF Integration    \n"
+            + "Hi Conal,\n"
+            + "\n"
+            + "No it is not ready yet.\n"
+            + "\n"
+            + "Thanks, Navamoni"
+            + "\n";
+        final String expectedLastDivider = "------- End of forwarded message -------\n------- End of forwarded message -------\n";
+
+        final Document doc = createDocumentWithSuppliedStrings(expectedEmail1, expectedDivider, expectedEmail2, expectedLastDivider);
+
+        final JepExecutor j = Mockito.mock(JepExecutor.class);
+        when(j.getMessageIndexes(Mockito.any())).thenReturn(Arrays.asList(0, 14));
+
+        final EmailSplitter emailSplitter = new EmailSplitter(j);
+        emailSplitter.generateEmailTags(doc);
+
+        Assert.assertTrue("Assert the first email is as expected.",
+                          doc.getRootElement().getChild("CONTENT").getChildren().get(0).getValue().equals(expectedEmail1));
+        Assert.assertTrue("Assert the divider is as expected.",
+                          doc.getRootElement().getChild("CONTENT").getChildren().get(1).getValue().equals(expectedDivider));
+        Assert.assertTrue("Assert the second email is as expected.",
+                          doc.getRootElement().getChild("CONTENT").getChildren().get(2).getValue().equals(expectedEmail2));
+        Assert.assertTrue("Assert the second divider is as expected.",
+                          doc.getRootElement().getChild("CONTENT").getChildren().get(3).getValue().equals(expectedLastDivider));
     }
 
     /**

--- a/worker-markup-core/src/test/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitterTest.java
+++ b/worker-markup-core/src/test/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitterTest.java
@@ -249,7 +249,7 @@ public class EmailSplitterTest
         //Assert value of email content should not have changed during processing
         Assert.assertTrue("The email is not as expected.", doc.getRootElement().getChild("CONTENT").getValue().equals(expectedEmail1));
     }
-    
+
     /**
      * Tests for running EmailSplitter with 2 emails and a divider between them
      *


### PR DESCRIPTION
Added testcases to cover this case to both the Familyhashing worker and markup core, markup core is a unit test.
**MARKUP BUILD**: http://sou-jenkins2.swinfra.net/job/CAFDataProcessing/view/Developer/job/CAFDataProcessing~worker-markup~SCMOD-8287~CI/  
**FAMILY HASHING BUILD**: http://sou-jenkins2.swinfra.net/job/caf/view/Developer/job/caf~worker-familyhashing~SCMOD-8287~CI/  