### PR TITLE
SCMOD-9780: Update image to use Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
                 <version>2.6</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>2.3.3</version>
+            </dependency>
+            <dependency>
                 <groupId>jaxen</groupId>
                 <artifactId>jaxen</artifactId>
                 <version>1.1.6</version>

--- a/release-notes-3.2.0.md
+++ b/release-notes-3.2.0.md
@@ -1,11 +1,9 @@
-!not-ready-for-release!
 
 #### Version Number
 ${version-number}
 
 #### New Features
-- **SCMOD-9780**: Updated containers to Java 11
+- **SCMOD-9780**: Updated image to use Java 11
 
 #### Known Issues
 - None
-

--- a/release-notes-3.2.0.md
+++ b/release-notes-3.2.0.md
@@ -4,5 +4,8 @@
 ${version-number}
 
 #### New Features
+- **SCMOD-9780**: Updated containers to Java 11
 
 #### Known Issues
+- None
+

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -301,7 +301,7 @@
                             <alias>worker-markup-fs</alias>
                             <name>${dockerDataProcessingOrg}worker-markup${dockerProjectVersion}</name>
                             <build>
-                                <from>cafinternal/prereleases:opensuse-jeptalon-3.0.0-SNAPSHOT</from>
+                                <from>cafinternal/prereleases:opensuse-jeptalon-3.0.0-SCMOD-9775-SNAPSHOT</from>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
                                     <Build.Date>${maven.build.timestamp}</Build.Date>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>worker-markup-testing</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -297,7 +297,7 @@
                             <alias>worker-markup-fs</alias>
                             <name>${dockerDataProcessingOrg}worker-markup${dockerProjectVersion}</name>
                             <build>
-                                <from>cafapi/opensuse-jeptalon:2</from>
+                                <from>cafinternal/prereleases:opensuse-jeptalon-3.0.0-SNAPSHOT</from>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
                                     <Build.Date>${maven.build.timestamp}</Build.Date>

--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -301,7 +301,7 @@
                             <alias>worker-markup-fs</alias>
                             <name>${dockerDataProcessingOrg}worker-markup${dockerProjectVersion}</name>
                             <build>
-                                <from>cafinternal/prereleases:opensuse-jeptalon-3.0.0-SCMOD-9775-SNAPSHOT</from>
+                                <from>cafinternal/prereleases:opensuse-jeptalon-3.0.0-SNAPSHOT</from>
                                 <labels>
                                     <Build.Number>${project.version}</Build.Number>
                                     <Build.Date>${maven.build.timestamp}</Build.Date>


### PR DESCRIPTION
Tried updating this to use the caf dependency bom but it did not take any work off rabbit during tests, my guess is that it doesn't have a healthcheck or it does not get called. Therefore I just added the jakarta.xml.bind-api dependency individually.