### PR TITLE
858036: Prevent strings like "57 Alice Springs" causing exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>com.hpe.caf.externals</groupId>
                 <artifactId>natty</artifactId>
-                <version>0.15.3-393</version>
+                <version>0.16.0-SNAPSHO</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>com.hpe.caf.externals</groupId>
                 <artifactId>natty</artifactId>
-                <version>0.16.0-SNAPSHO</version>
+                <version>0.16.0-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>

--- a/release-notes-3.4.0.md
+++ b/release-notes-3.4.0.md
@@ -4,5 +4,11 @@
 ${version-number}
 
 #### New Features
+- None
+
+#### Bug Fixes
+- 858036 Upgraded to latest version of the natty-date-parser.  
+  This fixes an issue where trying to markup a string such as "57 Alice Springs" was resulting in an exception being thrown.
 
 #### Known Issues
+- None


### PR DESCRIPTION
Upgraded to latest version of the natty-date-parser.  This fixes an issue where trying to markup a string such as "57 Alice Springs" was resulting in an exception being thrown.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=858036