### PR TITLE
US857114: Move RabbitMQ AMQP communication to use TLS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,62 +279,62 @@
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>standard-worker-container</artifactId>
                 <type>pom</type>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>util-rabbitmq</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-api</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-caf</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-configs</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-core</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-default-configs</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-queue-rabbit</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-store-fs</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-store-http</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-store-mem</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework</groupId>
                 <artifactId>worker-tracking-report</artifactId>
-                <version>7.0.0-1167</version>
+                <version>8.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework.testing</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -339,12 +339,12 @@
             <dependency>
                 <groupId>com.github.workerframework.testing</groupId>
                 <artifactId>workerframework-testing-integration</artifactId>
-                <version>2.0.0-189</version>
+                <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.github.workerframework.testing</groupId>
                 <artifactId>workerframework-testing-util</artifactId>
-                <version>2.0.0-189</version>
+                <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/worker-markup-container-fs/test-configs/cfg_test_worker-markup_RabbitConfiguration
+++ b/worker-markup-container-fs/test-configs/cfg_test_worker-markup_RabbitConfiguration
@@ -2,6 +2,7 @@
     "backoffInterval": 1,
     "maxBackoffInterval": 30,
     "maxAttempts": 20,
+    "rabbitProtocol": "amqp",
     "rabbitHost": "rabbitmq",
     "rabbitPort": 5672,
     "rabbitUser": "guest",

--- a/worker-markup-container-fs/test-configs/cfg_test_worker-markup_RabbitWorkerQueueConfiguration
+++ b/worker-markup-container-fs/test-configs/cfg_test_worker-markup_RabbitWorkerQueueConfiguration
@@ -4,5 +4,6 @@
     "retryQueue": "markupworker-test-input-1",
     "rejectedQueue": "markupworker-test-rejected-1",
     "retryLimit": 2,
-    "maxPriority": 32
+    "maxPriority": 32,
+    "queueType": "quorum"
 }


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=857114