### PR TITLE
US849017: Fix illegal group reference

### DIFF
--- a/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/TalonEmailSplitter.java
+++ b/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/TalonEmailSplitter.java
@@ -167,7 +167,7 @@ public final class TalonEmailSplitter
         // Converts msg_body into a unicode.
 
         final StringBuffer stringBuffer = new StringBuffer();
-        final Matcher matcher = RE_LINK.matcher(msgBody);
+        final Matcher matcher = RE_LINK.matcher(Matcher.quoteReplacement(msgBody));
         while (matcher.find()) {
             final int newlineIndex = msgBody.substring(0, matcher.start()).lastIndexOf("\n");
             if (msgBody.charAt(newlineIndex + 1) == '>') {

--- a/worker-markup-core/src/test/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitterTest.java
+++ b/worker-markup-core/src/test/java/com/github/cafdataprocessing/worker/markup/core/EmailSplitterTest.java
@@ -510,6 +510,17 @@ public class EmailSplitterTest
         Assert.assertTrue(assertCorrectAmountOfEmailElements(doc, 1));
     }
 
+    @Test
+    public void splitEmailTestSingleEmailWithDollarCharacter() throws ExecutionException, InterruptedException, JDOMException, IOException
+    {
+        Document doc = createDummyDocumentOneEmailWithDollarWithinLinkBrackets();
+
+        EmailSplitter emailSplitter = new EmailSplitter();
+        emailSplitter.generateEmailTags(doc);
+
+        Assert.assertTrue(assertCorrectAmountOfEmailElements(doc, 1));
+    }
+
     /**
      * Test for running EmailSplitter with a chain of two emails
      *
@@ -655,6 +666,31 @@ public class EmailSplitterTest
         Document doc = saxBuilder.build(new ByteArrayInputStream(s.getBytes()));
         return doc;
     }
+
+    private Document createDummyDocumentOneEmailWithDollarWithinLinkBrackets() throws JDOMException, IOException
+    {
+        String s = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<root>"
+                + "<CONTENT>"
+                + "From: Reid, Andy      "
+                + "Sent: 22 July 2016 10:21 AM      "
+                + "To: Paul, Navamoni &lt;paul.navamoni@hpe.com&gt;; Hardy, Dermot &lt;dermot.hardy@hpe.com&gt;      "
+                + "Cc: Ploch, Krzysztof &lt;krzysztof.ploch@hpe.com&gt;      "
+                + "Subject: RE: iSTF - CAF Integration    "
+                + "     Hi Navamoni,            "
+                + "Is this ready yet?      "
+                + "      Thanks      Andy          "
+                + "To UNSUBSCRIBE from this mailing list, go to:"
+                + "&lt;http://bye.emf3.com/handler.cfm?email=$('mailID')&gt;"
+                + "</CONTENT>"
+                + "</root>";
+
+        SAXBuilder saxBuilder = new SAXBuilder();
+
+        Document doc = saxBuilder.build(new ByteArrayInputStream(s.getBytes()));
+        return doc;
+    }
+
     /**
      * Create dummy document containing one email
      *


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=849017

Issue I see that is the occurrence of '$' in the content and when we are trying to do content manipulations in [replaceLinkBrackets](https://github.com/CAFDataProcessing/worker-markup/blob/c7d450c8503789faba81c689fce1f30451143410/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/TalonEmailSplitter.java#L174) line 174 & 176, '$' is not allowed to be in the replacement string according to [javadoc](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Matcher.html#appendReplacement(java.lang.StringBuffer,java.lang.String)).




> Note that backslashes (\) and dollar signs ($) in the replacement string may cause the results to be different than if it were being treated as a literal replacement string. Dollar signs may be treated as references to captured subsequences as described above, and backslashes are used to escape literal characters in the replacement string.



So would need to cleanse the content by escaping the '$' by calling [quoteReplacement](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Matcher.html#quoteReplacement) before using in [line 170](https://github.com/CAFDataProcessing/worker-markup/blob/c7d450c8503789faba81c689fce1f30451143410/worker-markup-core/src/main/java/com/github/cafdataprocessing/worker/markup/core/TalonEmailSplitter.java#L170).