### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-markup-container-fs/pom.xml
+++ b/worker-markup-container-fs/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-markup-container-fs</artifactId>
+    <name>worker-markup-container-fs</name>
     <packaging>pom</packaging>
 
     <!-- Properties for the worker. -->

--- a/worker-markup-core/pom.xml
+++ b/worker-markup-core/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-markup-core</artifactId>
+    <name>worker-markup-core</name>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/worker-markup-shared/pom.xml
+++ b/worker-markup-shared/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-markup-shared</artifactId>
+    <name>worker-markup-shared</name>
 
     <dependencies>
         <dependency>

--- a/worker-markup-testing/pom.xml
+++ b/worker-markup-testing/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-markup-testing</artifactId>
+    <name>worker-markup-testing</name>
 
     <dependencies>
         <dependency>

--- a/worker-markup/pom.xml
+++ b/worker-markup/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>worker-markup</artifactId>
+    <name>worker-markup</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210